### PR TITLE
Add TimeZoom functionality to ARSim

### DIFF
--- a/docs/groovy/test.md
+++ b/docs/groovy/test.md
@@ -5,7 +5,7 @@
 Starts an ArSim instance and runs the available unit tests
 **Usage:**
 ```
-RunArUnitTests(project: "$PROJECT_DIR", configuration: "UnitTest", tests: "all", output: 'TestResults', port: 80);
+RunArUnitTests(project: "$PROJECT_DIR", configuration: "UnitTest", tests: "all", output: 'TestResults', port: 80, timezoom:'0');
 ```
 
 **Options:**
@@ -23,7 +23,7 @@ RunArUnitTests(project: "$PROJECT_DIR", configuration: "UnitTest", tests: "all",
 Runs the mapp View integration tests
 **Usage:**
 ```
-RunMappViewIntegrationTests(project: "$PROJECT_DIR", configuration: "Simulation", integrationTestDir: "IntegrationTests");
+RunMappViewIntegrationTests(project: "$PROJECT_DIR", configuration: "Simulation", integrationTestDir: "IntegrationTests", timezoom:'0');
 ```
 
 **Options:**

--- a/docs/python/automation_studio.md
+++ b/docs/python/automation_studio.md
@@ -159,7 +159,7 @@ Starts an ArSim instance and wait for it to be in run mode before returning
 
 **Usage:**
 ``` console 
-    python StartArSim.py --simulationDirectory C:\ArSim
+    python StartArSim.py --simulationDirectory C:\ArSim --timeZoom +1
 ```
 
 **Options:**

--- a/resources/scripts/StartArSim.py
+++ b/resources/scripts/StartArSim.py
@@ -5,9 +5,9 @@ import time
 import socket
 from subprocess import Popen
 
-def launchArSim(simulationDir) -> socket:
-    print('starting ArSim')
-    Popen(f'"{simulationDir}\\ar000loader.exe" -i127.0.0.1 -p4003', shell=False)
+def launchArSim(simulationDir, timeZoom) -> socket:
+    print('starting ArSim with timeZoom =', timeZoom)
+    Popen(f'"{simulationDir}\\ar000loader.exe" -i127.0.0.1 -p4003 -f{timeZoom}', shell=False)
 
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     connected = False
@@ -46,9 +46,10 @@ def waitForRunMode(s) -> bool:
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument('-s', '--simulationDirectory', help='ArSim installation directory', dest='simulationDir', required=True)
+    parser.add_argument('-t', '--timeZoom', help='TimeZoom for Simulator', dest='timeZoom', default='0', required=False)
     args = parser.parse_args()
 
-    s = launchArSim(args.simulationDir)
+    s = launchArSim(args.simulationDir, args.timeZoom)
     returnVal = waitForRunMode(s)
     time.sleep(5)
     sys.exit(0 if (returnVal == True) else 1)

--- a/vars/RunArUnitTests.groovy
+++ b/vars/RunArUnitTests.groovy
@@ -3,8 +3,10 @@ def call(Map config = [:]){
 	config.configuration = config.configuration  ?: 'UnitTest'
     config.output = config.output ?: 'TestResults'
     config.port = config.port ?: 80
+    config.timezoom = config.timezoom ?: '0'
+
     powershell(script: "python '${GetResources()}/scripts/CreateArSimInstallation.py' --project '${config.project}' --configuration '${config.configuration}' --simulationDirectory '${config.project}/ArSim'");
-    powershell(script: "python '${GetResources()}/scripts/StartArSim.py' --simulationDirectory '${config.project}/ArSim'");
+    powershell(script: "python '${GetResources()}/scripts/StartArSim.py' --simulationDirectory '${config.project}/ArSim' --timeZoom '${config.timezoom}'");
     powershell(script: "python '${GetResources()}/scripts/RunUnitTests.py' --test ${config.tests} --output '${config.project}/${config.output}' --port ${config.port}");
     powershell(script: "python '${GetResources()}/scripts/StopArSim.py' --simulationDirectory '${config.project}/ArSim'");
     powershell(script: "python '${GetResources()}/scripts/ProcessCodeCoverage.py' --project '${config.project}' --config '${config.configuration}'")    

--- a/vars/RunMappViewIntegrationTests.groovy
+++ b/vars/RunMappViewIntegrationTests.groovy
@@ -1,11 +1,12 @@
 def call(Map config = [:]){
 	config.configuration = config.configuration  ?: 'Simulation'
     config.buildArSim = config.buildArSim ?: true
+    config.timezoom = config.timezoom ?: '0'    
     
     if (config.buildArSim)
         powershell(script: "python '${GetResources()}/scripts/CreateArSimInstallation.py' --project '${config.project}' --configuration '${config.configuration}' --simulationDirectory '${config.project}/ArSim'");
         
-    powershell(script: "python '${GetResources()}/scripts/StartArSim.py' --simulationDirectory '${config.project}/ArSim'");
+    powershell(script: "python '${GetResources()}/scripts/StartArSim.py' --simulationDirectory '${config.project}/ArSim' --timeZoom '${config.timezoom}'");
     powershell(returnStdout: true, script: "pytest '${config.integrationTestDir}' --junit-xml='${config.project}/IntegrationTestResults/results.xml' --alluredir='${config.project}/AllureReport' --suppress-tests-failed-exit-code");
     powershell(script: "python '${GetResources()}/scripts/StopArSim.py' --simulationDirectory '${config.project}/ArSim'");
 }


### PR DESCRIPTION
With timeZoom the ARSim can be launched with a particular timeZoom. If not called the parameter, default 1:1 value is used